### PR TITLE
Editing TypeResolvers for higher versions of Jackson

### DIFF
--- a/.idea/artifacts/kelp_core_jar.xml
+++ b/.idea/artifacts/kelp_core_jar.xml
@@ -1,0 +1,14 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="kelp-core:jar">
+    <output-path>$PROJECT_DIR$/../jars</output-path>
+    <root id="archive" name="kelp-core.jar">
+      <element id="module-output" name="kelp-core" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.4/jackson-databind-2.6.4.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.4/jackson-core-2.6.4.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar" path-in-jar="/" />
+    </root>
+  </artifact>
+</component>

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA">
+    <option name="configuration">
+      <map>
+        <entry key="location-0" value="CLASSPATH:/sun_checks.xml:The default Checkstyle rules" />
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_annotations_2_6_0.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_annotations_2_6_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.6.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_core_2_6_4.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_core_2_6_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-core:2.6.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.4/jackson-core-2.6.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.4/jackson-core-2.6.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.4/jackson-core-2.6.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_databind_2_6_4.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_databind_2_6_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.4/jackson-databind-2.6.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.4/jackson-databind-2.6.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.4/jackson-databind-2.6.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_code_findbugs_jsr305_1_3_9.xml
+++ b/.idea/libraries/Maven__com_google_code_findbugs_jsr305_1_3_9.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.code.findbugs:jsr305:1.3.9">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_guava_guava_11_0_2.xml
+++ b/.idea/libraries/Maven__com_google_guava_guava_11_0_2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.guava:guava:11.0.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/11.0.2/guava-11.0.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/11.0.2/guava-11.0.2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/11.0.2/guava-11.0.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_googlecode_efficient_java_matrix_library_ejml_0_24.xml
+++ b/.idea/libraries/Maven__com_googlecode_efficient_java_matrix_library_ejml_0_24.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.googlecode.efficient-java-matrix-library:ejml:0.24">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/efficient-java-matrix-library/ejml/0.24/ejml-0.24.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/efficient-java-matrix-library/ejml/0.24/ejml-0.24-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/googlecode/efficient-java-matrix-library/ejml/0.24/ejml-0.24-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__dom4j_dom4j_1_6_1.xml
+++ b/.idea/libraries/Maven__dom4j_dom4j_1_6_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: dom4j:dom4j:1.6.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/dom4j/dom4j/1.6.1/dom4j-1.6.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/dom4j/dom4j/1.6.1/dom4j-1.6.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__junit_junit_4_11.xml
+++ b/.idea/libraries/Maven__junit_junit_4_11.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: junit:junit:4.11">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.11/junit-4.11.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.11/junit-4.11-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.11/junit-4.11-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__net_sf_trove4j_trove4j_3_0_3.xml
+++ b/.idea/libraries/Maven__net_sf_trove4j_trove4j_3_0_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: net.sf.trove4j:trove4j:3.0.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_apache_commons_commons_lang3_3_4.xml
+++ b/.idea/libraries/Maven__org_apache_commons_commons_lang3_3_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.apache.commons:commons-lang3:3.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.4/commons-lang3-3.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_hamcrest_hamcrest_core_1_3.xml
+++ b/.idea/libraries/Maven__org_hamcrest_hamcrest_core_1_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.hamcrest:hamcrest-core:1.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_javassist_javassist_3_16_1_GA.xml
+++ b/.idea/libraries/Maven__org_javassist_javassist_3_16_1_GA.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.javassist:javassist:3.16.1-GA">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/javassist/javassist/3.16.1-GA/javassist-3.16.1-GA.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/javassist/javassist/3.16.1-GA/javassist-3.16.1-GA-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/javassist/javassist/3.16.1-GA/javassist-3.16.1-GA-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_reflections_reflections_0_9_9_RC1.xml
+++ b/.idea/libraries/Maven__org_reflections_reflections_0_9_9_RC1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.reflections:reflections:0.9.9-RC1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/reflections/reflections/0.9.9-RC1/reflections-0.9.9-RC1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/reflections/reflections/0.9.9-RC1/reflections-0.9.9-RC1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/reflections/reflections/0.9.9-RC1/reflections-0.9.9-RC1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_7.xml
+++ b/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_7.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:slf4j-api:1.7.7">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.7/slf4j-api-1.7.7-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_slf4j_simple_1_7_7.xml
+++ b/.idea/libraries/Maven__org_slf4j_slf4j_simple_1_7_7.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:slf4j-simple:1.7.7">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-simple/1.7.7/slf4j-simple-1.7.7-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__xml_apis_xml_apis_1_0_b2.xml
+++ b/.idea/libraries/Maven__xml_apis_xml_apis_1_0_b2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: xml-apis:xml-apis:1.0.b2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>it.uniroma2.sag.kelp</groupId>
 	<artifactId>kelp-core</artifactId>
@@ -123,7 +123,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.1</version>
+			<version>3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -143,7 +143,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.3.1</version>
+			<version>2.6.4</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>

--- a/src/main/java/it/uniroma2/sag/kelp/data/clustering/ClusterExampleTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/data/clustering/ClusterExampleTypeResolver.java
@@ -16,20 +16,21 @@
 
 package it.uniroma2.sag.kelp.data.clustering;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by
@@ -103,6 +104,11 @@ public class ClusterExampleTypeResolver implements TypeIdResolver {
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0
 				+ "'");
+	}
+
+	@Override
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	@Override

--- a/src/main/java/it/uniroma2/sag/kelp/data/clustering/ClusterTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/data/clustering/ClusterTypeResolver.java
@@ -16,20 +16,21 @@
 
 package it.uniroma2.sag.kelp.data.clustering;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by
@@ -106,6 +107,11 @@ public class ClusterTypeResolver implements TypeIdResolver {
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0
 				+ "'");
+	}
+
+	@Override
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	@Override

--- a/src/main/java/it/uniroma2/sag/kelp/data/example/ExampleTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/data/example/ExampleTypeResolver.java
@@ -16,20 +16,21 @@
 package it.uniroma2.sag.kelp.data.example;
 
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -96,6 +97,10 @@ public class ExampleTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {		

--- a/src/main/java/it/uniroma2/sag/kelp/data/label/LabelTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/data/label/LabelTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.data.label;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -97,6 +98,11 @@ public class LabelTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+	@Override
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	@Override

--- a/src/main/java/it/uniroma2/sag/kelp/data/representation/RepresentationTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/data/representation/RepresentationTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.data.representation;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -95,6 +96,11 @@ public class RepresentationTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {		

--- a/src/main/java/it/uniroma2/sag/kelp/kernel/KernelTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/kernel/KernelTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.kernel;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -95,6 +96,11 @@ public class KernelTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {		

--- a/src/main/java/it/uniroma2/sag/kelp/kernel/cache/KernelCacheTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/kernel/cache/KernelCacheTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.kernel.cache;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -95,6 +96,10 @@ public class KernelCacheTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {		

--- a/src/main/java/it/uniroma2/sag/kelp/kernel/cache/SquaredNormCacheTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/kernel/cache/SquaredNormCacheTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.kernel.cache;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -95,6 +96,11 @@ public class SquaredNormCacheTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {		

--- a/src/main/java/it/uniroma2/sag/kelp/kernel/pairs/KernelOnPairs.java
+++ b/src/main/java/it/uniroma2/sag/kelp/kernel/pairs/KernelOnPairs.java
@@ -30,7 +30,7 @@ public abstract class KernelOnPairs extends KernelComposition{
 	protected float kernelComputation(Example exA, Example exB) {
 		
 		if(!(exA instanceof ExamplePair) || !(exB instanceof ExamplePair)){
-			throw new java.lang.IllegalArgumentException("Invalid object: expected two ExamplePairs to compute any kernel over pairs");
+			throw new IllegalArgumentException("Invalid object: expected two ExamplePairs to compute any kernel over pairs");
 		}
 		ExamplePair pairA = (ExamplePair)exA;
 		ExamplePair pairB = (ExamplePair)exB;

--- a/src/main/java/it/uniroma2/sag/kelp/learningalgorithm/LearningAlgorithmTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/learningalgorithm/LearningAlgorithmTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.learningalgorithm;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -99,6 +100,11 @@ public class LearningAlgorithmTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+	@Override
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	@Override

--- a/src/main/java/it/uniroma2/sag/kelp/predictionfunction/PredictionFunctionTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/predictionfunction/PredictionFunctionTypeResolver.java
@@ -15,20 +15,21 @@
 
 package it.uniroma2.sag.kelp.predictionfunction;
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by Jackson library during
@@ -99,6 +100,11 @@ public class PredictionFunctionTypeResolver implements TypeIdResolver{
 			return type;
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0 + "'");
+	}
+
+	@Override
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	@Override

--- a/src/main/java/it/uniroma2/sag/kelp/wordspace/WordspaceTypeResolver.java
+++ b/src/main/java/it/uniroma2/sag/kelp/wordspace/WordspaceTypeResolver.java
@@ -15,20 +15,21 @@
 package it.uniroma2.sag.kelp.wordspace;
 
 
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * It is a class implementing <code>TypeIdResolver</code> which will be used by
@@ -101,6 +102,11 @@ public class WordspaceTypeResolver implements TypeIdResolver {
 		}
 		throw new IllegalStateException("cannot find mapping for '" + arg0
 				+ "'");
+	}
+
+
+	public JavaType typeFromId(DatabindContext var1, String arg0) {
+		return typeFromId(arg0);
 	}
 
 	public String idFromValueAndType(Object arg0, Class<?> arg1) {


### PR DESCRIPTION
Upgrading the maven dependency 
versions of older packages
jackson-databind to 2.6.4
commons-lang3 to 3.4
and updating all the TypeResolvers.
The Updated version of Jackson is more robust.
(Can now work for earlier versions of Jackson too.)
